### PR TITLE
fixes #6: Openfire 4.8.0 compatibility

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,12 +46,13 @@ Presence Plugin Changelog
 
 <p><b>1.7.2</b> -- (TBD)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/6'>#6</a>] - Fix Openfire 4.8.0 incompatibility</li>
 </ul>
 
 <p><b>1.7.1</b> -- November 12, 2020</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType.</li>
-    <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/1'>#1] - Fix Maven build</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/1'>#1</a>] - Fix Maven build</li>
     <li>Requires Openfire 4.1.1.</li>
 </ul>
 

--- a/changelog.html
+++ b/changelog.html
@@ -47,6 +47,7 @@ Presence Plugin Changelog
 <p><b>1.7.2</b> -- (TBD)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/6'>#6</a>] - Fix Openfire 4.8.0 incompatibility</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/5'>#5</a>] - Guard against unloaded images</li>
 </ul>
 
 <p><b>1.7.1</b> -- November 12, 2020</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Exposes presence information through HTTP.</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
-    <date>11/12/2020</date>
+    <date>2024-01-19</date>
     <minServerVersion>4.1.1</minServerVersion>
     
     <adminconsole>		

--- a/src/java/org/jivesoftware/openfire/plugin/PresencePlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/PresencePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,11 +225,14 @@ public class PresencePlugin implements Plugin, Component {
             // Return component presence
             return presence;
         }
-        if (targetJID.getNode() == null ||
-                !UserManager.getInstance().isRegisteredUser(targetJID.getNode())) {
+
+        if (targetJID.getNode() == null) {
             // Sender is requesting presence information of an anonymous user
             throw new UserNotFoundException("Username is null");
         }
+        // throws UserNotFound if the user doesn't exist.
+        User user = userManager.getUser(targetJID.getNode());
+
         if (!isPresencePublic()) {
             if (sender == null) {
                 throw new UserNotFoundException("Sender is null");
@@ -243,7 +246,6 @@ public class PresencePlugin implements Plugin, Component {
                 }
             }
         }
-        User user = userManager.getUser(targetJID.getNode());
         return presenceManager.getPresence(user);
     }
 }

--- a/src/java/org/jivesoftware/openfire/plugin/presence/ImagePresenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/plugin/presence/ImagePresenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,9 @@ class ImagePresenceProvider extends PresenceInfoProvider {
 
     private static final Logger Log = LoggerFactory.getLogger(ImagePresenceProvider.class);
     
-    private PresenceStatusServlet servlet;
-    private Map<String, byte[]> imageCache = new HashMap<String, byte[]>();
-    private Map<String, String> imageTypeCache = new HashMap<String, String>();
+    private final PresenceStatusServlet servlet;
+    private final Map<String, byte[]> imageCache = new HashMap<>();
+    private final Map<String, String> imageTypeCache = new HashMap<>();
 
     public ImagePresenceProvider(PresenceStatusServlet servlet) {
         this.servlet = servlet;
@@ -71,29 +71,29 @@ class ImagePresenceProvider extends PresenceInfoProvider {
     public void sendInfo(HttpServletRequest request,
             HttpServletResponse response, Presence presence) throws IOException {
         if (presence == null) {
-            writeImageContent(request, response, "offline", servlet.offline);
+            writeImageContent(request, response, "offline", servlet.getOffline());
         }
         else if (presence.getShow() == null) {
-            writeImageContent(request, response, "available", servlet.available);
+            writeImageContent(request, response, "available", servlet.getAvailable());
         }
         else if (presence.getShow().equals(org.xmpp.packet.Presence.Show.away)) {
-            writeImageContent(request, response, "away", servlet.away);
+            writeImageContent(request, response, "away", servlet.getAway());
         }
         else if (presence.getShow().equals(org.xmpp.packet.Presence.Show.chat)) {
-            writeImageContent(request, response, "chat", servlet.chat);
+            writeImageContent(request, response, "chat", servlet.getChat());
         }
         else if (presence.getShow().equals(org.xmpp.packet.Presence.Show.dnd)) {
-            writeImageContent(request, response, "dnd", servlet.dnd);
+            writeImageContent(request, response, "dnd", servlet.getDnd());
         }
         else if (presence.getShow().equals(org.xmpp.packet.Presence.Show.xa)) {
-            writeImageContent(request, response, "xa", servlet.xa);
+            writeImageContent(request, response, "xa", servlet.getXa());
         }
     }
 
     @Override
     public void sendUserNotFound(HttpServletRequest request, HttpServletResponse response)
             throws IOException {
-        writeImageContent(request, response, "forbidden", servlet.offline);
+        writeImageContent(request, response, "forbidden", servlet.getOffline());
     }
 
     private void writeImageContent(HttpServletRequest request, HttpServletResponse response,
@@ -122,8 +122,8 @@ class ImagePresenceProvider extends PresenceInfoProvider {
                     URLConnection connection = new URL(url).openConnection();
                     InputStream in = connection.getInputStream();
                     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-                    byte buffer[] = new byte[1024 * 4];
-                    int last_read_bytes = 0;
+                    byte[] buffer = new byte[1024 * 4];
+                    int last_read_bytes;
                     while ((last_read_bytes = in.read(buffer)) != -1) {
                         bytes.write(buffer, 0, last_read_bytes);
                     }


### PR DESCRIPTION
No longer uses API that got removed in Openfire 4.8.0.

This code now uses other API that was already available in older versions of Openfire. This means that there should not be a minimum server requirement for Openfire 4.8.0 for this change.