### PR TITLE
fix #9: 'text' type requests should not return null

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ Presence Plugin Changelog
 
 <p><b>1.7.3</b> -- TBD</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-presence-plugin/issues/9'>#9</a>] - 'Text' type requests should not return 'null'</li>
 </ul>
 
 <p><b>1.7.2</b> -- January 19, 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Exposes presence information through HTTP.</description>
     <author>Jive Software</author>
     <version>${project.version}</version>
-    <date>2024-01-19</date>
+    <date>2024-01-20</date>
     <minServerVersion>4.1.1</minServerVersion>
     
     <adminconsole>		

--- a/src/java/org/jivesoftware/openfire/plugin/presence/TextPresenceProvider.java
+++ b/src/java/org/jivesoftware/openfire/plugin/presence/TextPresenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, Ignite Realtime Foundation 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,12 @@ class TextPresenceProvider extends PresenceInfoProvider {
             catch (UserNotFoundException e) {}
             presence.setFrom(targetJID);
         }
-        out.println(presence.getStatus());
+
+        if (presence.getStatus() != null && !presence.getStatus().isEmpty()) {
+            out.println(presence.getStatus().trim());
+        } else {
+            out.println(JiveGlobals.getProperty("plugin.presence.available.status", "Available"));
+        }
         out.flush();
     }
 


### PR DESCRIPTION
The 'text' type request returns the last known 'status' (not 'show'). It's a bit dodgy that this takes the last known status when a user is offline (where other endpoints return a 'current' status). This behavior is not changed in this commit (warrants further investigation - it is cleary implemented intentionally).

When the status is absent, this endpoint returns a value `null`. The status is an optional element, not set by all clients. It is undesirable to have a 'null' value. This commit replaces it with an hardcoded value of 'Available', matching the implementation that hardcodedly sets 'Unavailable' for clients that are offline _and_ do not have a 'last known' presence.